### PR TITLE
[General] Improve navigation on touchscreen and gamepad and revert so…

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -56,6 +56,10 @@ html,
   box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
 }
 
+.button:disabled {
+  cursor: not-allowed;
+}
+
 .button.is-small {
   min-width: 130px;
 }
@@ -79,7 +83,7 @@ html,
 }
 
 .button.is-secondary {
-  background: var(--download-button);
+  background: var(--accent);
 }
 
 .button.is-tertiary {
@@ -99,7 +103,7 @@ html,
 
 .button.is-secondary:hover {
   background: var(--download-button-overlay);
-  color: var(--text-tertiary);
+  color: var(--text-secondary);
 }
 
 .button.is-empty {
@@ -225,7 +229,20 @@ html,
   box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
 }
 
+.settingSelect:disabled {
+  cursor: not-allowed;
+}
+
+.settingSelect ~ span {
+  margin-block: auto;
+}
+
+.settingSelect.is-drop-down {
+  cursor: pointer;
+}
+
 .settingText {
+  cursor: default;
   margin-bottom: 14px;
   font: var(--font-secondary-regular);
   font-size: 16px;

--- a/src/components/UI/ActionIcons/index.css
+++ b/src/components/UI/ActionIcons/index.css
@@ -18,11 +18,13 @@
 .headerIcons > *:hover,
 .headerIcons > .svg-button > *:hover,
 .headerIcons > .svg-button:focus-visible > * {
-  color: var(--download-button);
+  color: var(--text-hover);
 }
 
-.svg-button > .selectedLayout {
-  color: var(--download-button);
+.headerIcons .svg-button > .selectedLayout,
+.headerIcons .svg-button > .selectedLayout:hover,
+.headerIcons .svg-button > .selectedLayout:focus-visible {
+  color: var(--accent);
 }
 
 .headerIcons > .svg-button > svg {

--- a/src/components/UI/Header/index.css
+++ b/src/components/UI/Header/index.css
@@ -105,6 +105,7 @@ option {
 }
 
 .totalGamesText {
+  cursor: default;
   right: 55px;
   top: 108px;
   grid-area: total;

--- a/src/components/UI/InfoBox/index.css
+++ b/src/components/UI/InfoBox/index.css
@@ -1,15 +1,16 @@
 .infoBox {
+  cursor: default;
   width: 100%;
   padding: 12px 22px 12px 22px;
   font-size: 16px;
   line-height: 19px;
   background-color: var(--input-background);
   border-radius: 10px;
-  margin-inline: 16px;
   text-align: start;
 }
 
 .helpLink {
+  margin-block-start: 4px;
   transition: 500ms;
   color: var(--accent);
   cursor: pointer;
@@ -19,7 +20,6 @@
   align-items: center;
   min-width: 45px;
   justify-content: flex-start;
-  margin-inline-start: 16px;
 }
 
 .helpLink:hover {

--- a/src/components/UI/InfoBox/index.tsx
+++ b/src/components/UI/InfoBox/index.tsx
@@ -23,6 +23,7 @@ export default function InfoBox({ children, text }: Props) {
   return (
     <>
       <a
+        role={'tooltip'}
         href="#"
         className="helpLink"
         onClick={(e) => {

--- a/src/components/UI/LanguageSelector/index.tsx
+++ b/src/components/UI/LanguageSelector/index.tsx
@@ -102,7 +102,7 @@ export default function LanguageSelector({
     <select
       data-testid="languageSelector"
       onChange={(event) => handleLanguageChange(event.target.value)}
-      className={className}
+      className={`${className} is-drop-down`}
       value={currentLanguage}
     >
       {Object.keys(languageLabels).map((lang) => renderOption(lang))}

--- a/src/components/UI/SmallInfo/index.css
+++ b/src/components/UI/SmallInfo/index.css
@@ -18,6 +18,6 @@
 }
 
 .clickable:hover {
-  color: var(--text-hover);
+  color: var(--link-highlight);
   transition: 300ms;
 }

--- a/src/components/UI/SvgButton/index.css
+++ b/src/components/UI/SvgButton/index.css
@@ -1,4 +1,5 @@
 .svg-button {
+  cursor: pointer;
   border: none;
   background: none;
   padding: 0;

--- a/src/components/UI/ToggleSwitch/index.css
+++ b/src/components/UI/ToggleSwitch/index.css
@@ -15,15 +15,23 @@
   height: 0;
 }
 
-.switch:hover .checkmark {
+.toggleWrapper:hover span {
+  transition: 350ms;
+  color: var(--text-hover);
+}
+
+.switch:hover .checkmark,
+.toggleWrapper:hover .switch .checkmark {
   border-color: var(--text-hover);
 }
 
-.switch:hover input:checked ~ .checkmark {
+.switch:hover input:checked ~ .checkmark,
+.toggleWrapper:hover .switch input:checked ~ .checkmark {
   border-color: var(--text-hover);
   background-color: var(--text-hover);
 }
-.swtich:hover input:checked ~ .checkmark:after {
+.switch:hover input:checked ~ .checkmark:after,
+.toggleWrapper:hover .switch input:checked ~ .checkmark:after {
   border-color: var(--input-background);
 }
 
@@ -66,58 +74,4 @@
   -webkit-transform: rotate(45deg);
   -ms-transform: rotate(45deg);
   transform: rotate(45deg);
-}
-
-/* The slider */
-.slider {
-  position: relative;
-  cursor: pointer;
-  display: inline-block;
-  width: 100%;
-  height: 100%;
-  background: none;
-  border: 2px solid;
-  -webkit-transition: 0.4s;
-  transition: 0.4s;
-}
-
-span.slider.round {
-  top: -1.25px;
-}
-
-.slider:before {
-  position: absolute;
-  content: '';
-  height: 6px;
-  width: 6px;
-  left: 2px;
-  bottom: 1px;
-  background-color: #dadada;
-  -webkit-transition: 0.4s;
-  transition: 0.4s;
-}
-
-.slider:focus-visible {
-  outline: 1px solid var(--download-button);
-}
-
-input:checked + .slider:focus-visible {
-  outline: -webkit-focus-ring-color auto 1px;
-}
-
-input:checked + .slider {
-  border-color: var(--link-highlight);
-}
-
-input:checked + .slider:before {
-  background-color: var(--link-highlight);
-  transform: translateX(9px);
-}
-
-.slider.round {
-  border-radius: 60px;
-}
-
-.slider.round:before {
-  border-radius: 50%;
 }

--- a/src/components/UI/ToggleSwitch/index.tsx
+++ b/src/components/UI/ToggleSwitch/index.tsx
@@ -18,7 +18,7 @@ export default function ToggleSwitch(props: Props) {
     dataTestId = 'toggleSwitch'
   } = props
   return (
-    <label className="switch" aria-label={title}>
+    <div className="switch" aria-label={title}>
       <input
         data-testid={dataTestId}
         disabled={disabled}
@@ -29,6 +29,6 @@ export default function ToggleSwitch(props: Props) {
       />
 
       <span {...props} className="checkmark" />
-    </label>
+    </div>
   )
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,9 +1,10 @@
 html {
   /* Colours */
-  --background: #151f3d; /* please stop using this var */
   --navbar-background: #151f3d;
   --input-background: #0d0f1c;
-  --background-transparent: #151f3dcb; /* NOTE please try avoid using the bg colours below (to ENDNOTE)*/
+  /* --- NOTE please try avoid using the bg colours below (to ENDNOTE) --- */
+  --background-transparent: #151f3dcb;
+  --background: #151f3d;
   --background-transparent-62: rgba(66, 69, 70, 0.62);
   --background-darker: #0d0f1c;
   --background-darker-80: #0d0f1ce0;
@@ -14,7 +15,8 @@ html {
     #0d0f1cd2 64%
   );
   --background-light: #17237c;
-  --background-color: #13172a; /* ENDNOTE */
+  --background-color: #13172a;
+  /* --- ENDNOTE --- */
   --tooltip-background-color: #0d0e0e;
   --menu-background-color: #0d0e0e;
   --text-hover: #59d0ea;

--- a/src/screens/Game/GamePage/index.css
+++ b/src/screens/Game/GamePage/index.css
@@ -17,7 +17,7 @@
   font-weight: 500;
   font-size: 25px;
   line-height: 30px;
-  color: var(--accent);
+  color: var(--text-default);
   text-align: left;
 }
 
@@ -28,12 +28,17 @@
 }
 
 .gameInfo {
+  cursor: default;
   text-align: initial;
   font-size: 1rem;
   color: var(--text-default);
   display: flex;
   flex-direction: column;
   max-width: 650px;
+}
+
+.gameInfo .title {
+  color: var(--accent);
 }
 
 .gameInfo > .settingSelect {

--- a/src/screens/Game/GameRequirements/index.css
+++ b/src/screens/Game/GameRequirements/index.css
@@ -12,7 +12,8 @@
 }
 
 table td.specs {
-  color: var(--download-button);
+  cursor: default;
+  color: var(--accent);
   opacity: 0.8;
 }
 

--- a/src/screens/Game/GameRequirements/index.tsx
+++ b/src/screens/Game/GameRequirements/index.tsx
@@ -21,7 +21,6 @@ function GameRequirements({ gameInfo }: Props) {
     >
       {haveSystemRequirements && is_game && (
         <>
-          <div className="title">System Requirements</div>
           <table>
             <tbody>
               <tr>

--- a/src/screens/Library/components/GameCard/index.css
+++ b/src/screens/Library/components/GameCard/index.css
@@ -33,7 +33,7 @@
 .gameCard > .progress {
   position: absolute;
   z-index: 5;
-  bottom: 10px;
+  bottom: 5px;
   left: 5px;
   color: var(--success);
   font-family: Rubik;
@@ -46,6 +46,7 @@
   word-wrap: break-word;
   padding: 2px;
   background: var(--background-gradient);
+  border-radius: 4px;
 }
 .gameCard > .progress svg {
   color: var(--success);
@@ -247,7 +248,7 @@
 }
 
 .downIcon > circle {
-  fill: var(--download-button);
+  fill: var(--accent);
 }
 
 .cancelIcon > circle {

--- a/src/screens/Library/components/InstallModal/index.css
+++ b/src/screens/Library/components/InstallModal/index.css
@@ -38,12 +38,17 @@
 
 .close-button {
   position: absolute;
-  right: 2rem;
-  top: 2rem;
+  right: 1.5rem;
+  top: 1.5rem;
   cursor: pointer;
+}
+.close-button svg {
+  width: 1.5rem;
+  height: 1.5rem;
 }
 
 .title {
+  cursor: default;
   color: var(--text-default);
   place-self: center;
   font-family: Cabin;

--- a/src/screens/Library/components/InstallModal/index.tsx
+++ b/src/screens/Library/components/InstallModal/index.tsx
@@ -383,7 +383,7 @@ export default function InstallModal({
             </button>
             <button
               onClick={() => handleInstall()}
-              className={`button is-primary`}
+              className={`button is-secondary`}
             >
               {getDownloadedProgress()
                 ? t('button.continue', 'Continue Download')

--- a/src/screens/Settings/components/GeneralSettings/index.tsx
+++ b/src/screens/Settings/components/GeneralSettings/index.tsx
@@ -338,12 +338,15 @@ export default function GeneralSettings({
               }`}
             </button>
           </span>
+          {!isWindows && (
+            <InfoBox text="infobox.help">{t('help.general')}</InfoBox>
+          )}
         </span>
       )}
-      {!isWindows && <InfoBox text="infobox.help">{t('help.general')}</InfoBox>}
+
       {isWindows && (
         <span className="setting">
-          <span className={classNames('toggleWrapper', { isRTL: isRTL })}>
+          <label className={classNames('toggleWrapper', { isRTL: isRTL })}>
             <ToggleSwitch
               dataTestId="syncToggle"
               value={isLinked}
@@ -351,11 +354,11 @@ export default function GeneralSettings({
               title={t('setting.egs-sync')}
             />
             <span>{t('setting.egs-sync')}</span>
-          </span>
+          </label>
         </span>
       )}
       <span className="setting">
-        <span className={classNames('toggleWrapper', { isRTL: isRTL })}>
+        <label className={classNames('toggleWrapper', { isRTL: isRTL })}>
           <ToggleSwitch
             dataTestId="exitToTray"
             value={exitToTray}
@@ -363,11 +366,11 @@ export default function GeneralSettings({
             title={t('setting.exit-to-tray')}
           />
           <span>{t('setting.exit-to-tray')}</span>
-        </span>
+        </label>
       </span>
       {exitToTray && (
         <span className="setting">
-          <span className={classNames('toggleWrapper', { isRTL: isRTL })}>
+          <label className={classNames('toggleWrapper', { isRTL: isRTL })}>
             <ToggleSwitch
               dataTestId="startInTray"
               value={startInTray}
@@ -375,11 +378,11 @@ export default function GeneralSettings({
               title={t('setting.start-in-tray', 'Start Minimized')}
             />
             <span>{t('setting.start-in-tray', 'Start Minimized')}</span>
-          </span>
+          </label>
         </span>
       )}
       <span className="setting">
-        <span className={classNames('toggleWrapper', { isRTL: isRTL })}>
+        <label className={classNames('toggleWrapper', { isRTL: isRTL })}>
           <ToggleSwitch
             value={showUnrealMarket}
             handleChange={() => toggleUnrealMarket()}
@@ -394,10 +397,10 @@ export default function GeneralSettings({
               'Show Unreal Marketplace (needs restart)'
             )}
           </span>
-        </span>
+        </label>
       </span>
       <span className="setting">
-        <span className={classNames('toggleWrapper', { isRTL: isRTL })}>
+        <label className={classNames('toggleWrapper', { isRTL: isRTL })}>
           <ToggleSwitch
             value={darkTrayIcon}
             handleChange={() => {
@@ -407,10 +410,10 @@ export default function GeneralSettings({
             title={t('setting.darktray', 'Use Dark Tray Icon (needs restart)')}
           />
           <span>{t('setting.darktray', 'Use Dark Tray Icon')}</span>
-        </span>
+        </label>
       </span>
       <span className="setting">
-        <span className={classNames('toggleWrapper', { isRTL: isRTL })}>
+        <label className={classNames('toggleWrapper', { isRTL: isRTL })}>
           <ToggleSwitch
             value={checkForUpdatesOnStartup}
             handleChange={toggleCheckUpdatesOnStartup}
@@ -425,15 +428,15 @@ export default function GeneralSettings({
               'Check For Updates On Startup'
             )}
           </span>
-        </span>
+        </label>
       </span>
       <span className="setting">
-        <span className={classNames('toggleWrapper', { isRTL: isRTL })}>
+        <label className={classNames('toggleWrapper', { isRTL: isRTL })}>
           <select
             data-testid="setMaxWorkers"
             onChange={(event) => setMaxWorkers(Number(event.target.value))}
             value={maxWorkers}
-            className="settingSelect smaller"
+            className="settingSelect smaller is-drop-down"
           >
             {Array.from(Array(maxCpus).keys()).map((n) => (
               <option key={n + 1}>{n + 1}</option>
@@ -443,7 +446,7 @@ export default function GeneralSettings({
             </option>
           </select>
           <span>{t('setting.maxworkers')}</span>
-        </span>
+        </label>
       </span>
     </>
   )

--- a/src/screens/Settings/components/OtherSettings/index.tsx
+++ b/src/screens/Settings/components/OtherSettings/index.tsx
@@ -92,6 +92,24 @@ export default function OtherSettings({
   const supportsShortcuts = isWin || isLinux
   const shouldRenderFpsOption = !isMacNative && !isWin && !isLinuxNative
 
+  const info = (
+    <InfoBox text="infobox.help">
+      {t('help.other.part1')}
+      <strong>{`${t('help.other.part2')} `}</strong>
+      {t('help.other.part3')}
+      <br />
+      {!isDefault && (
+        <span>
+          {t('help.other.part4')}
+          <strong>{t('help.other.part5')}</strong>
+          {t('help.other.part6')}
+          <strong>{` -nolauncher `}</strong>
+          {t('help.other.part7')}
+        </span>
+      )}
+    </InfoBox>
+  )
+
   return (
     <>
       {!isDefault && (
@@ -139,57 +157,57 @@ export default function OtherSettings({
 
       {shouldRenderFpsOption && (
         <span data-testid="otherSettings" className="setting">
-          <span className={classNames('toggleWrapper', { isRTL: isRTL })}>
+          <label className={classNames('toggleWrapper', { isRTL: isRTL })}>
             <ToggleSwitch
               value={showFps}
               handleChange={toggleFps}
               title={t('setting.showfps')}
             />
             <span>{t('setting.showfps')}</span>
-          </span>
+          </label>
         </span>
       )}
       {isLinux && (
         <>
           <span className="setting">
-            <span className={classNames('toggleWrapper', { isRTL: isRTL })}>
+            <label className={classNames('toggleWrapper', { isRTL: isRTL })}>
               <ToggleSwitch
                 value={useGameMode}
                 handleChange={toggleUseGameMode}
                 title={t('setting.gamemode')}
               />
               <span>{t('setting.gamemode')}</span>
-            </span>
+            </label>
           </span>
           <span className="setting">
-            <span className={classNames('toggleWrapper', { isRTL: isRTL })}>
+            <label className={classNames('toggleWrapper', { isRTL: isRTL })}>
               <ToggleSwitch
                 value={primeRun}
                 handleChange={togglePrimeRun}
                 title={t('setting.primerun', 'Enable Nvidia Prime Render')}
               />
               <span>{t('setting.primerun', 'Enable Nvidia Prime Render')}</span>
-            </span>
+            </label>
           </span>
           <span className="setting">
-            <span className={classNames('toggleWrapper', { isRTL: isRTL })}>
+            <label className={classNames('toggleWrapper', { isRTL: isRTL })}>
               <ToggleSwitch
                 value={audioFix}
                 handleChange={toggleAudioFix}
                 title={t('setting.audiofix')}
               />
               <span>{t('setting.audiofix')}</span>
-            </span>
+            </label>
           </span>
           <span className="setting">
-            <span className={classNames('toggleWrapper', { isRTL: isRTL })}>
+            <label className={classNames('toggleWrapper', { isRTL: isRTL })}>
               <ToggleSwitch
                 value={showMangohud}
                 handleChange={toggleMangoHud}
                 title={t('setting.mangohud')}
               />
               <span>{t('setting.mangohud')}</span>
-            </span>
+            </label>
           </span>
           {isLinuxNative && (
             <span className="setting">
@@ -207,20 +225,20 @@ export default function OtherSettings({
       )}
       {canRunOffline && (
         <span className="setting">
-          <span className={classNames('toggleWrapper', { isRTL: isRTL })}>
+          <label className={classNames('toggleWrapper', { isRTL: isRTL })}>
             <ToggleSwitch
               value={offlineMode}
               handleChange={toggleOffline}
               title={t('setting.offlinemode')}
             />
             <span>{t('setting.offlinemode')}</span>
-          </span>
+          </label>
         </span>
       )}
       {supportsShortcuts && isDefault && (
         <>
           <span className="setting">
-            <span className={classNames('toggleWrapper', { isRTL: isRTL })}>
+            <label className={classNames('toggleWrapper', { isRTL: isRTL })}>
               <ToggleSwitch
                 value={addDesktopShortcuts}
                 handleChange={toggleAddDesktopShortcuts}
@@ -235,10 +253,10 @@ export default function OtherSettings({
                   'Add desktop shortcuts automatically'
                 )}
               </span>
-            </span>
+            </label>
           </span>
           <span className="setting">
-            <span className={classNames('toggleWrapper', { isRTL: isRTL })}>
+            <label className={classNames('toggleWrapper', { isRTL: isRTL })}>
               <ToggleSwitch
                 value={addGamesToStartMenu}
                 handleChange={toggleAddGamesToStartMenu}
@@ -253,13 +271,13 @@ export default function OtherSettings({
                   'Add games to start menu automatically'
                 )}
               </span>
-            </span>
+            </label>
           </span>
         </>
       )}
       {isDefault && (
         <span className="setting">
-          <span className={classNames('toggleWrapper', { isRTL: isRTL })}>
+          <label className={classNames('toggleWrapper', { isRTL: isRTL })}>
             <ToggleSwitch
               value={discordRPC}
               handleChange={toggleDiscordRPC}
@@ -268,26 +286,26 @@ export default function OtherSettings({
             <span>
               {t('setting.discordRPC', 'Enable Discord Rich Presence')}
             </span>
-          </span>
+          </label>
         </span>
       )}
       {isDefault && (
         <span className="setting">
-          <span className={classNames('toggleWrapper', { isRTL: isRTL })}>
+          <label className={classNames('toggleWrapper', { isRTL: isRTL })}>
             <select
               data-testid="setMaxRecentGames"
               onChange={(event) =>
                 setMaxRecentGames(Number(event.target.value))
               }
               value={maxRecentGames}
-              className="settingSelect smaller"
+              className="settingSelect smaller is-drop-down "
             >
               {Array.from(Array(10).keys()).map((n) => (
                 <option key={n + 1}>{n + 1}</option>
               ))}
             </select>
             <span>{t('setting.maxRecentGames', 'Recent Games to Show')}</span>
-          </span>
+          </label>
         </span>
       )}
       {!isWin && (
@@ -306,6 +324,7 @@ export default function OtherSettings({
               onChange={handleOtherOptions}
             />
           </span>
+          {info}
         </span>
       )}
       {!isDefault && (
@@ -324,23 +343,9 @@ export default function OtherSettings({
               onChange={handleLauncherArgs}
             />
           </span>
+          {info}
         </span>
       )}
-      <InfoBox text="infobox.help">
-        {t('help.other.part1')}
-        <strong>{`${t('help.other.part2')} `}</strong>
-        {t('help.other.part3')}
-        <br />
-        {!isDefault && (
-          <span>
-            {t('help.other.part4')}
-            <strong>{t('help.other.part5')}</strong>
-            {t('help.other.part6')}
-            <strong>{` -nolauncher `}</strong>
-            {t('help.other.part7')}
-          </span>
-        )}
-      </InfoBox>
     </>
   )
 }

--- a/src/screens/Settings/components/SyncSaves/index.tsx
+++ b/src/screens/Settings/components/SyncSaves/index.tsx
@@ -171,7 +171,7 @@ export default function SyncSaves({
         </span>
       </span>
       <span className="setting">
-        <span className={classNames('toggleWrapper', { isRTL: isRTL })}>
+        <label className={classNames('toggleWrapper', { isRTL: isRTL })}>
           <ToggleSwitch
             value={autoSyncSaves}
             disabled={!savesPath.length}
@@ -179,7 +179,7 @@ export default function SyncSaves({
             title={t('setting.autosync')}
           />
           <span>{t('setting.autosync')}</span>
-        </span>
+        </label>
       </span>
       <InfoBox text="infobox.help">
         <ul>

--- a/src/screens/Settings/components/WineSettings/index.tsx
+++ b/src/screens/Settings/components/WineSettings/index.tsx
@@ -263,30 +263,31 @@ export default function WineSettings({
             )
           }
           value={wineVersion.name}
-          className="settingSelect"
+          className="settingSelect is-drop-down"
         >
           {altWine.map(({ name }) => (
             <option key={name}>{name}</option>
           ))}
         </select>
+        <InfoBox text="infobox.help">
+          <span>{t('help.wine.part1')}</span>
+          <ul>
+            <i>
+              <li>~/.config/heroic/tools/wine</li>
+              <li>~/.config/heroic/tools/proton</li>
+              <li>~/.steam/root/compatibilitytools.d</li>
+              <li>~/.steam/steamapps/common</li>
+              <li>~/.local/share/lutris/runners/wine</li>
+              <li>~/.var/app/com.valvesoftware.Steam (Steam Flatpak)</li>
+              <li>/usr/share/steam</li>
+              <li>Everywhere on the system (CrossOver Mac)</li>
+              <li>/opt/cxoffice (CrossOver Linux)</li>
+            </i>
+          </ul>
+          <span>{t('help.wine.part2')}</span>
+        </InfoBox>
       </span>
-      <InfoBox text="infobox.help">
-        <span>{t('help.wine.part1')}</span>
-        <ul>
-          <i>
-            <li>~/.config/heroic/tools/wine</li>
-            <li>~/.config/heroic/tools/proton</li>
-            <li>~/.steam/root/compatibilitytools.d</li>
-            <li>~/.steam/steamapps/common</li>
-            <li>~/.local/share/lutris/runners/wine</li>
-            <li>~/.var/app/com.valvesoftware.Steam (Steam Flatpak)</li>
-            <li>/usr/share/steam</li>
-            <li>Everywhere on the system (CrossOver Mac)</li>
-            <li>/opt/cxoffice (CrossOver Linux)</li>
-          </i>
-        </ul>
-        <span>{t('help.wine.part2')}</span>
-      </InfoBox>
+
       {wineVersion.name.includes('CrossOver') && (
         <span className="setting">
           <span className={classNames('settingText', { isRTL: isRTL })}>
@@ -305,7 +306,7 @@ export default function WineSettings({
       )}
       {isLinux && !isProton && (
         <span className="setting">
-          <span className={classNames('toggleWrapper', { isRTL: isRTL })}>
+          <label className={classNames('toggleWrapper', { isRTL: isRTL })}>
             <ToggleSwitch
               value={autoInstallDxvk}
               handleChange={() => {
@@ -324,12 +325,12 @@ export default function WineSettings({
             <span>
               {t('setting.autodxvk', 'Auto Install/Update DXVK on Prefix')}
             </span>
-          </span>
+          </label>
         </span>
       )}
       {isLinux && !isProton && (
         <span className="setting">
-          <span className={classNames('toggleWrapper', { isRTL: isRTL })}>
+          <label className={classNames('toggleWrapper', { isRTL: isRTL })}>
             <ToggleSwitch
               value={autoInstallVkd3d}
               handleChange={() => {
@@ -348,11 +349,11 @@ export default function WineSettings({
             <span>
               {t('setting.autovkd3d', 'Auto Install/Update VKD3D on Prefix')}
             </span>
-          </span>
+          </label>
         </span>
       )}
       <span className="setting">
-        <span className={classNames('toggleWrapper', { isRTL: isRTL })}>
+        <label className={classNames('toggleWrapper', { isRTL: isRTL })}>
           <ToggleSwitch
             value={enableFSR || false}
             handleChange={toggleFSR}
@@ -367,11 +368,11 @@ export default function WineSettings({
               'Enable FSR Hack (Wine version needs to support it)'
             )}
           </span>
-        </span>
+        </label>
       </span>
       {enableFSR && (
         <span className="setting">
-          <span className={classNames('toggleWrapper', { isRTL: isRTL })}>
+          <label className={classNames('toggleWrapper', { isRTL: isRTL })}>
             <select
               data-testid="setMaxRecentGames"
               onChange={(event) => setFsrSharpness(Number(event.target.value))}
@@ -385,13 +386,13 @@ export default function WineSettings({
             <span>
               {t('setting.FsrSharpnessStrenght', 'FSR Sharpness Strength')}
             </span>
-          </span>
+          </label>
         </span>
       )}
       {isLinux && (
         <>
           <span className="setting">
-            <span className={classNames('toggleWrapper', { isRTL: isRTL })}>
+            <label className={classNames('toggleWrapper', { isRTL: isRTL })}>
               <ToggleSwitch
                 value={enableResizableBar || false}
                 handleChange={toggleResizableBar}
@@ -406,10 +407,10 @@ export default function WineSettings({
                   'Enable Resizable BAR (NVIDIA RTX only)'
                 )}
               </span>
-            </span>
+            </label>
           </span>
           <span className="setting">
-            <span className={classNames('toggleWrapper', { isRTL: isRTL })}>
+            <label className={classNames('toggleWrapper', { isRTL: isRTL })}>
               <ToggleSwitch
                 value={enableEsync || false}
                 handleChange={toggleEsync}
@@ -417,10 +418,10 @@ export default function WineSettings({
                 title={t('setting.esync', 'Enable Esync')}
               />
               <span>{t('setting.esync', 'Enable Esync')}</span>
-            </span>
+            </label>
           </span>
           <span className="setting">
-            <span className={classNames('toggleWrapper', { isRTL: isRTL })}>
+            <label className={classNames('toggleWrapper', { isRTL: isRTL })}>
               <ToggleSwitch
                 value={enableFsync || false}
                 handleChange={toggleFsync}
@@ -428,7 +429,7 @@ export default function WineSettings({
                 title={t('setting.fsync', 'Enable Fsync')}
               />
               <span>{t('setting.fsync', 'Enable Fsync')}</span>
-            </span>
+            </label>
           </span>
         </>
       )}

--- a/src/screens/Settings/index.css
+++ b/src/screens/Settings/index.css
@@ -101,6 +101,7 @@
 
 .setting > .toggleWrapper {
   display: flex;
+  cursor: pointer;
   gap: 15px;
   align-content: flex-start;
   place-self: center;
@@ -109,7 +110,7 @@
   line-height: 19px;
   color: var(--text-default);
 }
-.toggleWrapper span {
+.toggleWrapper label {
   text-align: center;
   margin-block: auto;
 }
@@ -137,6 +138,7 @@
 }
 
 .save {
+  cursor: default;
   margin: 1em 0 0 18px;
   padding-block-end: 8px;
   display: flex;

--- a/src/screens/Settings/index.tsx
+++ b/src/screens/Settings/index.tsx
@@ -357,14 +357,15 @@ function Settings() {
   return (
     <>
       <div className="Settings">
-        <div className="settingsNavbar">
+        <nav role="list" className="settingsNavbar">
           {isDefault && (
-            <NavLink to={{ pathname: '/settings/default/general' }}>
+            <NavLink role="link" to={{ pathname: '/settings/default/general' }}>
               {t('settings.navbar.general')}
             </NavLink>
           )}
           {shouldRenderWineSettings && (
             <NavLink
+              role="link"
               to={{
                 pathname: `/settings/${appName}/wine`,
                 state: { runner: state?.runner }
@@ -375,6 +376,7 @@ function Settings() {
           )}
           {!isDefault && haveCloudSaving.cloudSaveEnabled && (
             <NavLink
+              role="link"
               data-testid="linkSync"
               to={{
                 pathname: `/settings/${appName}/sync`,
@@ -386,6 +388,7 @@ function Settings() {
           )}
           {
             <NavLink
+              role="link"
               to={{
                 pathname: `/settings/${appName}/other`,
                 state: { runner: state?.runner }
@@ -396,6 +399,7 @@ function Settings() {
           }
           {
             <NavLink
+              role="link"
               to={{
                 pathname: `/settings/${appName}/log`,
                 state: { runner: state?.runner }
@@ -404,10 +408,11 @@ function Settings() {
               {t('settings.navbar.log', 'Log')}
             </NavLink>
           }
-        </div>
-        <div className="settingsWrapper">
+        </nav>
+        <div role="list" className="settingsWrapper">
           {title && (
             <NavLink
+              role="link"
               to={returnPath}
               className="headerTitle"
               data-testid="headerTitle"

--- a/src/screens/WineManager/components/WineItem/index.css
+++ b/src/screens/WineManager/components/WineItem/index.css
@@ -22,10 +22,6 @@
   margin-left: 12px;
 }
 
-.downIcon > circle {
-  fill: var(--download-button);
-}
-
 .wineManagerListItem {
   display: grid;
   grid-template-columns: 2fr 1fr 2fr 1fr;


### PR DESCRIPTION
…me colours (#964)

* increase touch targets for checkboxes

* increase touch targets for checkboxes

* make gamepad control a bit better, QoL and colours returned to previous on refresh and play buttons

* navigation optimisations

* make wine-mangager dwnld icons orang

* fix colour idiosyncrasies and make exit of gameinstall modal a bit bigger

* border align and varname notes moved

* revert gamepage title colour

* [General] Offline mode only toggleable if allowed (#970)

* Offline mode only setable if allowed.

* i18n and lint

Co-authored-by: Flávio F Lima <flavioislima@gmail.com>

* [Fix] External urls not opening (#994)

* Add installation on MacOS via Homebrew (#992)

* increase touch targets for checkboxes

* move infobox to var

* remove unecessary curlies

* improve cursor changes on hover a LOT

* prettier linting

* https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/pull/964#discussion_r816948900

Co-authored-by: Niklas <61798668+Nocccer@users.noreply.github.com>
Co-authored-by: Flávio F Lima <flavioislima@gmail.com>
Co-authored-by: Paweł Lidwin <62100117+imLinguin@users.noreply.github.com>
Co-authored-by: Depal1 <47154119+Depal1@users.noreply.github.com>

<--- Put the description here --->

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
